### PR TITLE
Fix broken image download producing .txt files instead of images

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -140,10 +140,18 @@ function chartToImage(ext) {
       }
     }
 
-    document.body.appendChild(canvas);
-    if (ext === 'jpg') Canvas2Image.saveAsJPEG(canvas, chart.name);
-    else if (ext === 'png') Canvas2Image.saveAsPNG(canvas, chart.name);
-    document.body.removeChild(canvas);
+    const mimeType = ext === 'jpg' ? 'image/jpeg' : 'image/png';
+    const filename = (chart.name || 'chart') + '.' + ext;
+    canvas.toBlob((blob) => {
+      let url = URL.createObjectURL(blob);
+      let a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }, mimeType);
 
     $('#chartContainer').css({ border: '1px solid white' });
   });


### PR DESCRIPTION
## Problem
Clicking the Download button exports a broken `.txt` file (e.g. `jpeg.txt`) 
instead of a valid image. This is caused by a bug in the `canvas2image` 
library's `saveAsImage` function, which generates an invalid MIME type:

  "data:image/jpeg;base64,...".replace("jpeg", "image/octet-stream")
  → "data:image/image/octet-stream;base64,..."

Modern browsers cannot handle this malformed data URL and fall back to 
downloading it as a text file.

## Solution
Replaced the broken `Canvas2Image` calls with a modern approach using 
`canvas.toBlob()` and a programmatically clicked `<a download>` element, 
which correctly exports `.jpg` and `.png` files.

## Changes
- `js/script.js`: Replaced `Canvas2Image.saveAsJPEG/saveAsPNG` calls in 
  `chartToImage()` with `canvas.toBlob()` + anchor download

Fixes #12
